### PR TITLE
v1.0.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 .env
 
 # Directories
-./tests
+tests/

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright © 2021 - 2024, Peter Dyumin
+Copyright © 2021 - present, Peter Dyumin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -124,13 +124,13 @@ go get github.com/julyskies/gohelpers
   **Example:**
 
   ```go
-  type animals struct {
+  type animalsStruct struct {
     Elephant string
     Hippo    string
     Lion     string
   }
 
-  animals := animals{
+  animals := animalsStruct{
     Elephant: "elephant",
     Hippo: "hippo",
     Lion: "lion",

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ go get github.com/julyskies/gohelpers
 - **`StructFields(value interface{}) ([]string, error)`**
 
   This helper function returns a slice of struct field names (similar to `Object.keys()` in Javascript). Method names are not included. The `value` argument should be a struct. Both public and private struct field names are returned.
+  
   `ObjectKeys` is an alias for this function.
 
   Please notice: this function will not return field names for the nested structs.
@@ -105,10 +106,10 @@ go get github.com/julyskies/gohelpers
   fmt.Println(fields) // [SomeStruct J K]
 
   // handling an error
-  result, err := gohelpers.StructFields("invalid argument type")
+  result, err := gohelpers.StructFields("not a struct")
   if err != nil {
+    fmt.Println(result)      // []
     fmt.Println(err.Error()) // provided argument type is not a struct
-    fmt.Println(result) // nil
   }
   ```
 
@@ -188,7 +189,7 @@ go get github.com/julyskies/gohelpers
     fields, _ = gohelpers.StructFieldsJson(User{}, params)
     fmt.Println(fields) // [firstName lastName Password status]
 
-    // skip ignored and missing tags
+    // skip ignored and missing tags / fields
     params = gohelpers.StructKeysJsonParams{
       SkipIgnoredFields: true,
       SkipMissingFields: true,
@@ -214,6 +215,7 @@ go get github.com/julyskies/gohelpers
 - **`StructValues(value interface{}) []string`**
 
   This helper function returns a slice of values as strings. These values are taken from the provided  `struct`. This function is similar to `Object.values()` in Javascript. Methods are not returned.
+  
   `ObjectValues` is an alias for this function.
 
   Please notice: nested struct values are returned as a single string.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Minimal required Golang version: **`v1.16`**.
 go get github.com/julyskies/gohelpers
 ```
 
-### Available helper functions
+### Available functions
 
 - **`IncludesInt(slice []int, value int) bool`**
 
@@ -71,29 +71,37 @@ go get github.com/julyskies/gohelpers
 
 - **`StructFields(value interface{}) ([]string, error)`**
 
-  This helper function returns a slice of struct field names (similar to `Object.keys()` in Javascript). Method names are not included. The `value` argument should be a struct. Both public and private struct field names are returned. `ObjectKeys` is an alias for this function.
+  This helper function returns a slice of struct field names (similar to `Object.keys()` in Javascript). Method names are not included. The `value` argument should be a struct. Both public and private struct field names are returned.
+  `ObjectKeys` is an alias for this function.
 
-  Please notice: this function will not return embedded field names (i. e. field names from the embedded structs).
+  Please notice: this function will not return field names for the nested structs.
 
   **Example:**
 
   ```go
-  type SomeStruct struct {
+  type someStruct struct {
     A       int
     B       string
     private bool
     Public  int
   }
-  fields, _ := gohelpers.StructFields(SomeStruct{})
+  fields, _ := gohelpers.StructFields(someStruct{})
   fmt.Println(fields) // [A B private Public]
 
-  // working with embedding is not supported
-  type Embedding struct {
-    SomeStruct
+  // method names are not returned
+  func (s someStruct) myMethod() string {
+    return s.B
+  }
+  fields, _ = gohelpers.StructFields(someStruct{})
+  fmt.Println(fields) // [A B private Public]
+
+  // working with nesting is not supported
+  type withNesting struct {
+    SomeStruct someStruct
     J int
     K string
   }
-  fields, _ = gohelpers.StructFields(Embedding{})
+  fields, _ = gohelpers.StructFields(withNesting{})
   fmt.Println(fields) // [SomeStruct J K]
 
   // handling an error
@@ -106,20 +114,109 @@ go get github.com/julyskies/gohelpers
 
 - **`StructFieldsJson(value interface{}, params gohelpers.StructKeysJsonParams) ([]string, error)`**
 
-  This helper function returns a slice of struct JSON field tags (similar to `Object.keys()` in Javascript). Method names are not included. The `value` argument should be a struct. Both public and private struct JSON field tags are returned.
+  This helper function returns a slice of struct field JSON tags (similar to `Object.keys()` in Javascript). Method names are not included. The `value` argument should be a struct. Both public and private struct field JSON tags are returned.
 
-  A second argument is required for this function, it should be `gohelpers.StructKeysJsonParams` struct, where you can specify the following:
+  `ObjectKeysJson` is an alias for this function.
+
+  Please notice: this function will not return field names for the nested structs.
+
+  This function requires a second argument - `gohelpers.StructKeysJsonParams` struct, where you can specify the following options:
 
   ```go
   type StructKeysJsonParams struct {
-	  ReplaceIgnoredFieldsWithFieldNames bool
-	  ReplaceMissingTagsWithFieldNames   bool
+	  SkipIgnoredFields bool
+	  SkipMissingFields bool
+  }
+  ```
+
+  - `SkipIgnoredFields` field determines if ignored JSON tags should be skipped (i. e. `json:"-"` and `json:"-,omitempty"`). If ignored fields are skipped, resulting slice will not include these struct fields. If they are not skipped, default field name will be included in resulting slice.
+
+  - `SkipMissingFields` field determines if missing or empty JSON tags should be skipped (i. e. if there is no JSON tag for a field, or if JSON tag equals to `json:""`, `json:",omitempty"` or `json:","`). If missing fields are skipped, resulting slice will not include these struct fields. If they are not skipped, default field name will be included in resulting slice.
+
+  Default options for this function available as `gohelpers.DefaultStructKeysJsonParams`:
+
+  ```go
+  // Skip ignored fields: false -> ignored JSON tags will be replaced with default field names.
+  // Skip missing fields: false -> default field names will be used instead of missing JSON tags.
+  var DefaultStructKeysJsonParams = StructKeysJsonParams{
+	  SkipIgnoredFields: false,
+	  SkipMissingFields: false,
+  }
+  ```
+
+  **Example:**
+
+  ```go
+  package main
+
+  import (
+    "fmt"
+
+    "github.com/julyskies/gohelpers"
+  )
+
+  type User struct {
+    Age       uint8  `json:""`
+    FirstName string `json:"firstName"`
+    LastName  string `json:"lastName"`
+    Password  string `json:"-"`
+    role      string
+    Status    string `json:"status,omitempty"`
+  }
+
+  func main() {
+    // get all fields and available JSON tags
+    fields, _ := gohelpers.StructFieldsJson(
+      User{},
+      gohelpers.DefaultStructKeysJsonParams,
+    )
+    fmt.Println(fields) // [Age firstName lastName Password role status]
+
+    // get all non-ignored fields and JSON tags
+    params := gohelpers.StructKeysJsonParams{
+      SkipIgnoredFields: true,
+      SkipMissingFields: false,
+    }
+    fields, _ = gohelpers.StructFieldsJson(User{}, params)
+    fmt.Println(fields) // [Age firstName lastName Role status]
+
+    // get all non-missing fields and JSON tags
+    params = gohelpers.StructKeysJsonParams{
+      SkipIgnoredFields: false,
+      SkipMissingFields: true,
+    }
+    fields, _ = gohelpers.StructFieldsJson(User{}, params)
+    fmt.Println(fields) // [firstName lastName Password status]
+
+    // skip ignored and missing tags
+    params = gohelpers.StructKeysJsonParams{
+      SkipIgnoredFields: true,
+      SkipMissingFields: true,
+    }
+    fields, _ = gohelpers.StructFieldsJson(User{}, params)
+    fmt.Println(fields) // [firstName lastName status]
+
+    // handling an error
+    result, err := gohelpers.StructFieldsJson(
+      "not a struct",
+      gohelpers.StructKeysJsonParams{
+        SkipIgnoredFields: true,
+        SkipMissingFields: true,
+      },
+    )
+    if err != nil {
+      fmt.Println(result)      // []
+      fmt.Println(err.Error()) // provided argument type is not a struct
+    }
   }
   ```
 
 - **`StructValues(value interface{}) []string`**
 
-  This helper function returns an array of values as strings. These values are taken from the provided  `struct`. Behaviour is similar to the `Object.values()` from JS. `ObjectValues` is an alias for this function.
+  This helper function returns a slice of values as strings. These values are taken from the provided  `struct`. This function is similar to `Object.values()` in Javascript. Methods are not returned.
+  `ObjectValues` is an alias for this function.
+
+  Please notice: nested struct values are returned as a single string.
 
   **Example:**
 
@@ -129,15 +226,31 @@ go get github.com/julyskies/gohelpers
     Hippo    string
     Lion     string
   }
-
   animals := animalsStruct{
     Elephant: "elephant",
-    Hippo: "hippo",
-    Lion: "lion",
+    Hippo:    "hippo",
+    Lion:     "lion",
   }
-
   values := gohelpers.StructValues(animals)
-  fmt.Println(values) // ["elephant", "hippo", "lion"]
+  fmt.Println(values) // [elephant, hippo, lion]
+
+  // nested struct
+  type nestedAnimals struct {
+    AnimalsStruct animalsStruct
+    Cat           string
+    Dog           string
+  }
+  moreAnimals := nestedAnimals{
+    AnimalsStruct: animalsStruct{
+      Elephant: "elephant",
+      Hippo:    "hippo",
+      Lion:     "lion",
+    },
+    Cat: "cat",
+    Dog: "dog",
+  }
+  values := gohelpers.StructValues(moreAnimals)
+  fmt.Println(values) // [{elephant hippo lion} cat dog]
   ```
 
 ### Aliases

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This package contains helper functions for Golang applications.
 
-Minimal required Golang version: **1.16**
+Minimal required Golang version: **`v1.16`**.
 
 ### Install
 
@@ -12,63 +12,150 @@ go get github.com/julyskies/gohelpers
 
 ### Available helper functions
 
-- `IncludesInt(array []int, value int) bool`
+- **`IncludesInt(slice []int, value int) bool`**
 
-  This helper function returns a boolean value if array of `int` values contains a specified `int` value.
+  This helper function returns a boolean value if a slice of `int` values contains a specified `int` value.
 
-- `IncludesString(array []string, value string) bool`
+  **Example:**
 
-  This helper function returns a boolean value if array of `string` values contains a specified `string` value.
+  ```go
+  slice := []int{1, 2, 4, 9}
+  result := gohelpers.IncludesInt(slice, 8)
+  fmt.Println(result) // false
+  ```
 
-- `MakeTimestamp() int64`
+- **`IncludesString(slice []string, value string) bool`**
+
+  This helper function returns a boolean value if slice of `string` values contains a specified `string` value.
+
+  **Example:**
+
+  ```go
+  slice := []string{"a", "b", "c"}
+  result := gohelpers.IncludesString(slice, "a")
+  fmt.Println(result) // true
+  ```
+
+- **`MakeTimestamp() int64`**
 
   This helper function returns a UNIX timestamp in milliseconds.
 
-- `MakeTimestampSeconds() int64`
+  **Example:**
+
+  ```go
+  timestamp := gohelpers.MakeTimestamp()
+  fmt.Println(timestamp) // 1627987461201
+  ```
+
+- **`MakeTimestampSeconds() int64`**
 
   This helper function returns a UNIX timestamp in seconds.
 
-- `ObjectValues(object interface{}) []string`
+    **Example:**
 
-  This helper function returns an array of values as strings. These values are taken from the provided  `struct`. Behaviour is similar to the `Object.values()` from JS.
+  ```go
+  timestamp := gohelpers.MakeTimestampSeconds()
+  fmt.Println(timestamp) // 1713957122
+  ```
 
-- `RandomString(length int) string`
+- **`RandomString(length int) string`**
 
   This helper function returns a random alphanumeric string of the provided length.
 
-### Example
+  **Example:**
 
-```go
-import "github.com/julyskies/gohelpers"
+  ```go
+  randomString := gohelpers.RandomString(8)
+  fmt.Println(randomString) // A9is5Try
+  ```
 
-type Animals struct {
-  Elephant string
-  Hippo    string
-  Lion     string
-}
+- **`StructFields(value interface{}) ([]string, error)`**
 
-func example() {
-  arrayOfInts := []int{1, 2, 3, 4, 9}
-  arrayOfStrings := []string{"a", "b", "c"}
-  animals := Animals{
+  This helper function returns a slice of struct field names (similar to `Object.keys()` in Javascript). Method names are not included. The `value` argument should be a struct. Both public and private struct field names are returned. `ObjectKeys` is an alias for this function.
+
+  Please notice: this function will not return embedded field names (i. e. field names from the embedded structs).
+
+  **Example:**
+
+  ```go
+  type SomeStruct struct {
+    A       int
+    B       string
+    private bool
+    Public  int
+  }
+  fields, _ := gohelpers.StructFields(SomeStruct{})
+  fmt.Println(fields) // [A B private Public]
+
+  // working with embedding is not supported
+  type Embedding struct {
+    SomeStruct
+    J int
+    K string
+  }
+  fields, _ = gohelpers.StructFields(Embedding{})
+  fmt.Println(fields) // [SomeStruct J K]
+
+  // handling an error
+  result, err := gohelpers.StructFields("invalid argument type")
+  if err != nil {
+    fmt.Println(err.Error()) // provided argument type is not a struct
+    fmt.Println(result) // nil
+  }
+  ```
+
+- **`StructFieldsJson(value interface{}, params gohelpers.StructKeysJsonParams) ([]string, error)`**
+
+  This helper function returns a slice of struct JSON field tags (similar to `Object.keys()` in Javascript). Method names are not included. The `value` argument should be a struct. Both public and private struct JSON field tags are returned.
+
+  A second argument is required for this function, it should be `gohelpers.StructKeysJsonParams` struct, where you can specify the following:
+
+  ```go
+  type StructKeysJsonParams struct {
+	  ReplaceIgnoredFieldsWithFieldNames bool
+	  ReplaceMissingTagsWithFieldNames   bool
+  }
+  ```
+
+- **`StructValues(value interface{}) []string`**
+
+  This helper function returns an array of values as strings. These values are taken from the provided  `struct`. Behaviour is similar to the `Object.values()` from JS. `ObjectValues` is an alias for this function.
+
+  **Example:**
+
+  ```go
+  type animals struct {
+    Elephant string
+    Hippo    string
+    Lion     string
+  }
+
+  animals := animals{
     Elephant: "elephant",
     Hippo: "hippo",
     Lion: "lion",
   }
 
-  includesInt := gohelpers.IncludesInt(arrayOfInts, 8) // false
+  values := gohelpers.StructValues(animals)
+  fmt.Println(values) // ["elephant", "hippo", "lion"]
+  ```
 
-  includesString := gohelpers.IncludesString(arrayOfStrings, "a") // true
-  
-  values := gohelpers.ObjectValues(animals) // ["elephant", "hippo", "lion"]
+### Aliases
 
-  randomString := gohelpers.RandomString(8) // A9is5Try
+Aliases are added for compatibility.
 
-  timestampMS := gohelpers.MakeTimestamp() // 1627987461201
+- **`ObjectKeys(value interface{}) ([]string, error)`**
 
-  timestampSeconds := gohelpers.MakeTimestampSeconds() // 1713957122
-}
-```
+  This is an alias for `StructFields` function.
+
+- **`ObjectKeysJson(value interface{}, params gohelpers.StructKeysJsonParams) ([]string, error)`**
+
+  This is an alias for `StructFieldsJson` function.
+
+- **`ObjectValues(value interface{}) []string`**
+
+  This is an alias for `StructValues` function.
+
 
 ### Testing
 

--- a/constants.go
+++ b/constants.go
@@ -5,13 +5,13 @@ const structFieldsTypeError string = "provided argument type is not a struct"
 const randomStringCharset string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 
 type StructKeysJsonParams struct {
-	ReplaceIgnoredFieldsWithFieldNames bool // use struct field name if `json:"-"` or if `json:"-,omitempty"`
-	ReplaceMissingTagsWithFieldNames   bool // use struct field name if there's no JSON tag, if `json:""`, if `json:",omitempty"`, if `json:","`
+	SkipIgnoredFields bool // skip field if `json:"-"` / `json:"-,omitempty"`
+	SkipMissingFields bool // skip field if there is no JSON tag, or tag is empty, i. e. `json:""` / `json:",omitempty"` / `json:","`
 }
 
-// Replace ignored fields with field names: true
-// Replace missing tags with field names: true
+// Skip ignored fields: false -> ignored JSON tags will be replaced with default field names.
+// Skip missing fields: false -> default field names will be used instead of missing JSON tags.
 var DefaultStructKeysJsonParams = StructKeysJsonParams{
-	ReplaceIgnoredFieldsWithFieldNames: true,
-	ReplaceMissingTagsWithFieldNames:   true,
+	SkipIgnoredFields: false,
+	SkipMissingFields: false,
 }

--- a/constants.go
+++ b/constants.go
@@ -1,41 +1,8 @@
 package gohelpers
 
-import "fmt"
-
-const objectKeysTypeError string = "provided argument type is not a struct"
+const structFieldsTypeError string = "provided argument type is not a struct"
 
 const randomStringCharset string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-type animals struct {
-	Elephant string
-	Hippo    string
-	Lion     string
-}
-
-type objectKeysTestStruct struct {
-	Public  string
-	private string
-}
-
-func (obj objectKeysTestStruct) testMethod() string {
-	return fmt.Sprintf("%s %s", obj.Public, obj.private)
-}
-
-type objectKeysJsonTestStruct struct {
-	Comma                int `json:","`
-	Empty                int `json:""`
-	Ignored              int `json:"-"`
-	Missing              int
-	EmptyWithOmitempty   int `json:",omitempty"`
-	IgonredWithOmitempty int `json:"-,omitempty"`
-	NormalField          int `json:"normalField"`
-	private              int `json:"private"`
-	privateWithOmitempty int `json:"private,omitempty"`
-}
-
-func (obj objectKeysJsonTestStruct) testMethod() string {
-	return fmt.Sprintf("%d %d", obj.NormalField, obj.private)
-}
 
 type StructKeysJsonParams struct {
 	ReplaceIgnoredFieldsWithFieldNames bool // use struct field name if `json:"-"` or if `json:"-,omitempty"`

--- a/constants.go
+++ b/constants.go
@@ -2,7 +2,15 @@ package gohelpers
 
 import "fmt"
 
-const OBJECT_KEYS_TYPE_ERROR string = "provided argument type is not a struct"
+const objectKeysTypeError string = "provided argument type is not a struct"
+
+const randomStringCharset string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+type animals struct {
+	Elephant string
+	Hippo    string
+	Lion     string
+}
 
 type objectKeysTestStruct struct {
 	Public  string
@@ -11,4 +19,32 @@ type objectKeysTestStruct struct {
 
 func (obj objectKeysTestStruct) testMethod() string {
 	return fmt.Sprintf("%s %s", obj.Public, obj.private)
+}
+
+type objectKeysJsonTestStruct struct {
+	Comma                int `json:","`
+	Empty                int `json:""`
+	Ignored              int `json:"-"`
+	Missing              int
+	EmptyWithOmitempty   int `json:",omitempty"`
+	IgonredWithOmitempty int `json:"-,omitempty"`
+	NormalField          int `json:"normalField"`
+	private              int `json:"private"`
+	privateWithOmitempty int `json:"private,omitempty"`
+}
+
+func (obj objectKeysJsonTestStruct) testMethod() string {
+	return fmt.Sprintf("%d %d", obj.NormalField, obj.private)
+}
+
+type StructKeysJsonParams struct {
+	ReplaceIgnoredFieldsWithFieldNames bool // use struct field name if `json:"-"` or if `json:"-,omitempty"`
+	ReplaceMissingTagsWithFieldNames   bool // use struct field name if there's no JSON tag, if `json:""`, if `json:",omitempty"`, if `json:","`
+}
+
+// Replace ignored fields with field names: true
+// Replace missing tags with field names: true
+var DefaultStructKeysJsonParams = StructKeysJsonParams{
+	ReplaceIgnoredFieldsWithFieldNames: true,
+	ReplaceMissingTagsWithFieldNames:   true,
 }

--- a/constants.go
+++ b/constants.go
@@ -1,0 +1,14 @@
+package gohelpers
+
+import "fmt"
+
+const OBJECT_KEYS_TYPE_ERROR string = "provided argument type is not a struct"
+
+type objectKeysTestStruct struct {
+	Public  string
+	private string
+}
+
+func (obj objectKeysTestStruct) testMethod() string {
+	return fmt.Sprintf("%s %s", obj.Public, obj.private)
+}

--- a/helpers.go
+++ b/helpers.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"strings"
 	"time"
 )
 
-// Check if provided int array includes specified int value
-func IncludesInt(array []int, value int) bool {
-	for _, element := range array {
+// Check if provided int slice includes specified int value
+func IncludesInt(slice []int, value int) bool {
+	for _, element := range slice {
 		if element == value {
 			return true
 		}
@@ -18,9 +19,9 @@ func IncludesInt(array []int, value int) bool {
 	return false
 }
 
-// Check if provided string array includes specified string value
-func IncludesString(array []string, value string) bool {
-	for _, element := range array {
+// Check if provided string slice includes specified string value
+func IncludesString(slice []string, value string) bool {
+	for _, element := range slice {
 		if element == value {
 			return true
 		}
@@ -38,12 +39,55 @@ func MakeTimestampSeconds() int64 {
 	return time.Now().Unix()
 }
 
-// Get an array (slice) of struct key names (similar to Object.keys() in JS).
+// This is an alias for StructKeys function.
+// Get a slice of struct field names (for both public and private fields).
+// This function is similar to Object.keys() in Javascript.
+// Method names are not included.
 // Works only for structs.
-func ObjectKeys(object interface{}) ([]string, error) {
-	reflected := reflect.TypeOf(object)
+func ObjectKeys(value interface{}) ([]string, error) {
+	return StructFields(value)
+}
+
+// This is an alias for StructKeysJson function.
+// Get a slice of struct JSON field tags (for both public and private fields).
+// This function is similar to Object.keys() in Javascript.
+// Method names are not included.
+// Works only for structs.
+func ObjectKeysJson(value interface{}, params StructKeysJsonParams) ([]string, error) {
+	return StructFieldsJson(value, params)
+}
+
+// This is an alias for StructValues function.
+// Get a slice of string values from struct fields (similar to Object.values() in JS).
+// Works only for structs.
+func ObjectValues(value interface{}) []string {
+	return StructValues(value)
+}
+
+// Create a random alphanumeric string with specified length
+func RandomString(length int) string {
+	if length <= 0 {
+		return ""
+	}
+
+	var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	accumulator := make([]byte, length)
+	for i := range accumulator {
+		accumulator[i] = randomStringCharset[seededRand.Intn(len(randomStringCharset))]
+	}
+
+	return string(accumulator)
+}
+
+// Get an array (slice) of struct field names (both public and private).
+// This function is similar to Object.keys() in Javascript.
+// Method names are not included.
+// Works only for structs.
+func StructFields(value interface{}) ([]string, error) {
+	reflected := reflect.TypeOf(value)
 	if reflected.Kind() != reflect.Struct {
-		return nil, errors.New(OBJECT_KEYS_TYPE_ERROR)
+		return nil, errors.New(objectKeysTypeError)
 	}
 	keys := make([]string, reflected.NumField())
 	for i := 0; i < reflected.NumField(); i += 1 {
@@ -52,11 +96,67 @@ func ObjectKeys(object interface{}) ([]string, error) {
 	return keys, nil
 }
 
-// Get an array (slice) of string values from struct keys (similar to Object.values() in JS).
+// Get a slice of struct JSON field tags (for both public and private fields).
+// This function is similar to Object.keys() in Javascript.
+// Method names are not included.
 // Works only for structs.
-func ObjectValues(object interface{}) []string {
+func StructFieldsJson(object interface{}, params StructKeysJsonParams) ([]string, error) {
+	reflected := reflect.TypeOf(object)
+	if reflected.Kind() != reflect.Struct {
+		return nil, errors.New(objectKeysTypeError)
+	}
+	var keys []string
+	for i := 0; i < reflected.NumField(); i += 1 {
+		jsonTag := reflected.Field(i).Tag.Get("json")
+
+		if jsonTag == "" || jsonTag == "," || jsonTag == ",omitempty" {
+			if params.ReplaceMissingTagsWithFieldNames {
+				jsonTag = reflected.Field(i).Name
+				keys = append(keys, jsonTag)
+				continue
+			} else {
+				continue
+			}
+		}
+
+		if jsonTag == "-" {
+			if params.ReplaceIgnoredFieldsWithFieldNames {
+				jsonTag = reflected.Field(i).Name
+				keys = append(keys, jsonTag)
+				continue
+			} else {
+				continue
+			}
+		}
+
+		tagPartials := strings.Split(jsonTag, ",")
+
+		if len(tagPartials) > 1 {
+			name := tagPartials[0]
+			if name != "-" {
+				keys = append(keys, name)
+				continue
+			}
+			if params.ReplaceIgnoredFieldsWithFieldNames {
+				keys = append(keys, reflected.Field(i).Name)
+			} else {
+				continue
+			}
+		}
+
+		if len(tagPartials) == 1 {
+			keys = append(keys, jsonTag)
+		}
+	}
+
+	return keys, nil
+}
+
+// Get a slice of string values from struct fields (similar to Object.values() in JS).
+// Works only for structs.
+func StructValues(value interface{}) []string {
 	var list []string
-	elements := reflect.ValueOf(object)
+	elements := reflect.ValueOf(value)
 
 	// if its a pointer, resolve its value
 	if elements.Kind() == reflect.Ptr {
@@ -67,22 +167,4 @@ func ObjectValues(object interface{}) []string {
 		list = append(list, fmt.Sprintf("%v", elements.Field(i).Interface()))
 	}
 	return list
-}
-
-// Create a random alphanumeric string with specified length
-func RandomString(length int) string {
-	if length <= 0 {
-		return ""
-	}
-
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-
-	var seededRand *rand.Rand = rand.New(rand.NewSource(time.Now().UnixNano()))
-
-	accumulator := make([]byte, length)
-	for i := range accumulator {
-		accumulator[i] = charset[seededRand.Intn(len(charset))]
-	}
-
-	return string(accumulator)
 }

--- a/helpers.go
+++ b/helpers.go
@@ -1,6 +1,7 @@
 package gohelpers
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"reflect"
@@ -37,14 +38,29 @@ func MakeTimestampSeconds() int64 {
 	return time.Now().Unix()
 }
 
-// Get an array of string values from struct keys (similar to Object.values() in JS)
+// Get an array (slice) of struct key names (similar to Object.keys() in JS).
+// Works only for structs.
+func ObjectKeys(object interface{}) ([]string, error) {
+	reflected := reflect.TypeOf(object)
+	if reflected.Kind() != reflect.Struct {
+		return nil, errors.New(OBJECT_KEYS_TYPE_ERROR)
+	}
+	keys := make([]string, reflected.NumField())
+	for i := 0; i < reflected.NumField(); i += 1 {
+		keys[i] = reflected.Field(i).Name
+	}
+	return keys, nil
+}
+
+// Get an array (slice) of string values from struct keys (similar to Object.values() in JS).
+// Works only for structs.
 func ObjectValues(object interface{}) []string {
 	var list []string
 	elements := reflect.ValueOf(object)
 
 	// if its a pointer, resolve its value
 	if elements.Kind() == reflect.Ptr {
-		elements = reflect.Indirect(elements)
+		elements = reflect.Indirect(elements) // TODO: coverage
 	}
 
 	for i := 0; i < elements.NumField(); i++ {

--- a/helpers.go
+++ b/helpers.go
@@ -39,19 +39,21 @@ func MakeTimestampSeconds() int64 {
 	return time.Now().Unix()
 }
 
-// This is an alias for StructKeys function.
+// This is an alias for StructFields function.
 // Get a slice of struct field names (for both public and private fields).
 // This function is similar to Object.keys() in Javascript.
 // Method names are not included.
+// Embedded field names are not included.
 // Works only for structs.
 func ObjectKeys(value interface{}) ([]string, error) {
 	return StructFields(value)
 }
 
-// This is an alias for StructKeysJson function.
+// This is an alias for StructFieldsJson function.
 // Get a slice of struct JSON field tags (for both public and private fields).
 // This function is similar to Object.keys() in Javascript.
 // Method names are not included.
+// Embedded field names are not included.
 // Works only for structs.
 func ObjectKeysJson(value interface{}, params StructKeysJsonParams) ([]string, error) {
 	return StructFieldsJson(value, params)
@@ -80,14 +82,15 @@ func RandomString(length int) string {
 	return string(accumulator)
 }
 
-// Get an array (slice) of struct field names (both public and private).
+// Get a slice of struct field names (for both public and private fields).
 // This function is similar to Object.keys() in Javascript.
 // Method names are not included.
+// Embedded field names are not included.
 // Works only for structs.
 func StructFields(value interface{}) ([]string, error) {
 	reflected := reflect.TypeOf(value)
 	if reflected.Kind() != reflect.Struct {
-		return nil, errors.New(objectKeysTypeError)
+		return nil, errors.New(structFieldsTypeError)
 	}
 	keys := make([]string, reflected.NumField())
 	for i := 0; i < reflected.NumField(); i += 1 {
@@ -99,12 +102,14 @@ func StructFields(value interface{}) ([]string, error) {
 // Get a slice of struct JSON field tags (for both public and private fields).
 // This function is similar to Object.keys() in Javascript.
 // Method names are not included.
+// Embedded field names are not included.
 // Works only for structs.
 func StructFieldsJson(object interface{}, params StructKeysJsonParams) ([]string, error) {
 	reflected := reflect.TypeOf(object)
 	if reflected.Kind() != reflect.Struct {
-		return nil, errors.New(objectKeysTypeError)
+		return nil, errors.New(structFieldsTypeError)
 	}
+
 	var keys []string
 	for i := 0; i < reflected.NumField(); i += 1 {
 		jsonTag := reflected.Field(i).Tag.Get("json")

--- a/helpers.go
+++ b/helpers.go
@@ -116,7 +116,7 @@ func StructFieldsJson(value interface{}, params StructKeysJsonParams) ([]string,
 		jsonTag := reflected.Field(i).Tag.Get("json")
 
 		if jsonTag == "" || jsonTag == "," || jsonTag == ",omitempty" {
-			if params.ReplaceMissingTagsWithFieldNames {
+			if !params.SkipMissingFields {
 				jsonTag = reflected.Field(i).Name
 				keys = append(keys, jsonTag)
 				continue
@@ -126,7 +126,7 @@ func StructFieldsJson(value interface{}, params StructKeysJsonParams) ([]string,
 		}
 
 		if jsonTag == "-" {
-			if params.ReplaceIgnoredFieldsWithFieldNames {
+			if !params.SkipIgnoredFields {
 				jsonTag = reflected.Field(i).Name
 				keys = append(keys, jsonTag)
 				continue
@@ -143,7 +143,7 @@ func StructFieldsJson(value interface{}, params StructKeysJsonParams) ([]string,
 				keys = append(keys, name)
 				continue
 			}
-			if params.ReplaceIgnoredFieldsWithFieldNames {
+			if !params.SkipIgnoredFields {
 				keys = append(keys, reflected.Field(i).Name)
 			} else {
 				continue

--- a/helpers.go
+++ b/helpers.go
@@ -43,7 +43,7 @@ func MakeTimestampSeconds() int64 {
 // Get a slice of struct field names (for both public and private fields).
 // This function is similar to Object.keys() in Javascript.
 // Method names are not included.
-// Embedded field names are not included.
+// Field names of nested structs are not included.
 // Works only for structs.
 func ObjectKeys(value interface{}) ([]string, error) {
 	return StructFields(value)
@@ -53,7 +53,7 @@ func ObjectKeys(value interface{}) ([]string, error) {
 // Get a slice of struct JSON field tags (for both public and private fields).
 // This function is similar to Object.keys() in Javascript.
 // Method names are not included.
-// Embedded field names are not included.
+// Field names of nested structs are not included.
 // Works only for structs.
 func ObjectKeysJson(value interface{}, params StructKeysJsonParams) ([]string, error) {
 	return StructFieldsJson(value, params)
@@ -61,6 +61,7 @@ func ObjectKeysJson(value interface{}, params StructKeysJsonParams) ([]string, e
 
 // This is an alias for StructValues function.
 // Get a slice of string values from struct fields (similar to Object.values() in JS).
+// Nested struct values are returned as a single string.
 // Works only for structs.
 func ObjectValues(value interface{}) []string {
 	return StructValues(value)
@@ -85,7 +86,7 @@ func RandomString(length int) string {
 // Get a slice of struct field names (for both public and private fields).
 // This function is similar to Object.keys() in Javascript.
 // Method names are not included.
-// Embedded field names are not included.
+// Field names of nested structs are not included.
 // Works only for structs.
 func StructFields(value interface{}) ([]string, error) {
 	reflected := reflect.TypeOf(value)
@@ -102,10 +103,10 @@ func StructFields(value interface{}) ([]string, error) {
 // Get a slice of struct JSON field tags (for both public and private fields).
 // This function is similar to Object.keys() in Javascript.
 // Method names are not included.
-// Embedded field names are not included.
+// Field names of nested structs are not included.
 // Works only for structs.
-func StructFieldsJson(object interface{}, params StructKeysJsonParams) ([]string, error) {
-	reflected := reflect.TypeOf(object)
+func StructFieldsJson(value interface{}, params StructKeysJsonParams) ([]string, error) {
+	reflected := reflect.TypeOf(value)
 	if reflected.Kind() != reflect.Struct {
 		return nil, errors.New(structFieldsTypeError)
 	}
@@ -158,6 +159,7 @@ func StructFieldsJson(object interface{}, params StructKeysJsonParams) ([]string
 }
 
 // Get a slice of string values from struct fields (similar to Object.values() in JS).
+// Nested struct values are returned as a single string.
 // Works only for structs.
 func StructValues(value interface{}) []string {
 	var list []string
@@ -165,10 +167,10 @@ func StructValues(value interface{}) []string {
 
 	// if its a pointer, resolve its value
 	if elements.Kind() == reflect.Ptr {
-		elements = reflect.Indirect(elements) // TODO: coverage
+		elements = reflect.Indirect(elements)
 	}
 
-	for i := 0; i < elements.NumField(); i++ {
+	for i := 0; i < elements.NumField(); i += 1 {
 		list = append(list, fmt.Sprintf("%v", elements.Field(i).Interface()))
 	}
 	return list

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -12,6 +12,12 @@ type animalsStruct struct {
 	Lion     string
 }
 
+type nestedAnimals struct {
+	Cat           string
+	Dog           string
+	AnimalsStruct animalsStruct
+}
+
 type testStructFields struct {
 	Public  string
 	private string
@@ -340,9 +346,40 @@ func TestObjectValues(t *testing.T) {
 	if len(values) != 3 {
 		t.Error("invalid resulting slice length")
 	}
-
 	if !IncludesString(values, "lion") {
 		t.Error("invalid values are included in resulting slice")
+	}
+
+	// pass a pointer
+	values = ObjectValues(&animals)
+	if len(values) != 3 {
+		t.Error("invalid resulting slice length")
+	}
+	if !IncludesString(values, "lion") {
+		t.Error("invalid values are included in resulting slice")
+	}
+
+	moreAnimals := nestedAnimals{
+		AnimalsStruct: animalsStruct{
+			Elephant: "elephant",
+			Hippo:    "hippo",
+			Lion:     "lion",
+		},
+		Cat: "cat",
+		Dog: "dog",
+	}
+	values = ObjectValues(&moreAnimals)
+	if len(values) != 3 {
+		t.Error("invalid resulting slice length")
+	}
+	if !IncludesString(values, "cat") {
+		t.Error("missing values from resulting slice")
+	}
+	if IncludesString(values, "hippo") {
+		t.Error("nested field values should be returned as a single string")
+	}
+	if !IncludesString(values, "{elephant hippo lion}") {
+		t.Error("nested field values should be returned as a single string")
 	}
 }
 
@@ -600,8 +637,39 @@ func TestStructValues(t *testing.T) {
 	if len(values) != 3 {
 		t.Error("invalid resulting slice length")
 	}
-
 	if !IncludesString(values, "lion") {
 		t.Error("invalid values are included in resulting slice")
+	}
+
+	// pass a pointer
+	values = StructValues(&animals)
+	if len(values) != 3 {
+		t.Error("invalid resulting slice length")
+	}
+	if !IncludesString(values, "lion") {
+		t.Error("invalid values are included in resulting slice")
+	}
+
+	moreAnimals := nestedAnimals{
+		AnimalsStruct: animalsStruct{
+			Elephant: "elephant",
+			Hippo:    "hippo",
+			Lion:     "lion",
+		},
+		Cat: "cat",
+		Dog: "dog",
+	}
+	values = StructValues(&moreAnimals)
+	if len(values) != 3 {
+		t.Error("invalid resulting slice length")
+	}
+	if !IncludesString(values, "cat") {
+		t.Error("missing values from resulting slice")
+	}
+	if IncludesString(values, "hippo") {
+		t.Error("nested field values should be returned as a single string")
+	}
+	if !IncludesString(values, "{elephant hippo lion}") {
+		t.Error("nested field values should be returned as a single string")
 	}
 }

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -59,6 +59,32 @@ func TestMakeTimestampSeconds(t *testing.T) {
 	}
 }
 
+func TestObjectKeys(t *testing.T) {
+	var testStruct objectKeysTestStruct
+
+	keys, keysError := ObjectKeys("invalid argument")
+	if keysError == nil {
+		t.Error("invalid handling of the wrong argument type")
+	}
+	if keysError.Error() != OBJECT_KEYS_TYPE_ERROR {
+		t.Error("invalid error message when providing the wrong argument type")
+	}
+	if keys != nil {
+		t.Error("invalid returned value when providing the wrong argument type")
+	}
+
+	keys, keysError = ObjectKeys(testStruct)
+	if keysError != nil {
+		t.Error("invalid error when providing correct argument")
+	}
+	if len(keys) != 2 {
+		t.Error("invalid resulting slice length")
+	}
+	if IncludesString(keys, "method") {
+		t.Error("should not include method names")
+	}
+}
+
 func TestObjectValues(t *testing.T) {
 	type Animals struct {
 		Elephant string

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -27,7 +27,7 @@ func (obj testStructFields) testMethod() string {
 	return obj.Public + obj.private
 }
 
-type testStructFieldsEmbedding struct {
+type testStructFieldsNesting struct {
 	testStructFields
 	A int
 	B string
@@ -50,7 +50,7 @@ func (obj testStructFieldsJson) testMethod() int {
 	return obj.NormalField + obj.private
 }
 
-type testStructFieldsJsonEmbedding struct {
+type testStructFieldsJsonNesting struct {
 	testStructFields
 	A int    `json:"a"`
 	B string `json:"b"`
@@ -132,7 +132,7 @@ func TestObjectKeys(t *testing.T) {
 		t.Error("should not include method names")
 	}
 
-	keys, keysError = ObjectKeys(testStructFieldsEmbedding{})
+	keys, keysError = ObjectKeys(testStructFieldsNesting{})
 	if keysError != nil {
 		t.Error("invalid error when providing correct argument")
 	}
@@ -140,10 +140,10 @@ func TestObjectKeys(t *testing.T) {
 		t.Error("invalid resulting slice length")
 	}
 	if !IncludesString(keys, "testStructFields") {
-		t.Error("resulting slice should contain the name of the embedded struct as an entry")
+		t.Error("resulting slice should contain the name of the nested struct as an entry")
 	}
 	if IncludesString(keys, "Public") || IncludesString(keys, "private") {
-		t.Error("resulting slice should not contain any embedded struct field names")
+		t.Error("resulting slice should not contain any nested struct field names")
 	}
 }
 
@@ -160,19 +160,19 @@ func TestObjectKeysJson(t *testing.T) {
 		t.Error("invalid returned value when providing the wrong argument type")
 	}
 
-	// testing embedding
+	// testing nesting
 	fields, fieldsError = ObjectKeysJson(
-		testStructFieldsJsonEmbedding{},
+		testStructFieldsJsonNesting{},
 		DefaultStructKeysJsonParams,
 	)
 	if fieldsError != nil {
 		t.Error("invalid error when providing correct arguments")
 	}
 	if len(fields) != 3 {
-		t.Error("invalid resulting slice length when using struct with embedding")
+		t.Error("invalid resulting slice length when using struct with nesting")
 	}
 	if IncludesString(fields, "normalField") {
-		t.Error("embedded fields should not be present in the resulting slice")
+		t.Error("nested fields should not be present in the resulting slice")
 	}
 
 	// testing basic functionality regardless of the used params
@@ -224,8 +224,8 @@ func TestObjectKeysJson(t *testing.T) {
 		}
 	}
 
-	// testing with default params: do not skip ignored tags & replace missing tags with field names
-	params := StructKeysJsonParams{true, true}
+	// testing with default params: do not skip ignored fields & replace missing tags with field names
+	params := StructKeysJsonParams{false, false}
 	fields, fieldsError = ObjectKeysJson(testStructFieldsJson{}, params)
 	basicFunctionalityTests(fields, fieldsError)
 	if len(fields) != 10 {
@@ -250,10 +250,10 @@ func TestObjectKeysJson(t *testing.T) {
 		t.Error("default field name should be used if JSON tag is not set")
 	}
 
-	// testing with non-default params: skip ignored tags & replace missing tags with field names
+	// testing with non-default params: skip ignored fields & replace missing tags with field names
 	params = StructKeysJsonParams{
-		ReplaceIgnoredFieldsWithFieldNames: false,
-		ReplaceMissingTagsWithFieldNames:   true,
+		SkipIgnoredFields: true,
+		SkipMissingFields: false,
 	}
 	fields, fieldsError = ObjectKeysJson(testStructFieldsJson{}, params)
 	basicFunctionalityTests(fields, fieldsError)
@@ -279,8 +279,8 @@ func TestObjectKeysJson(t *testing.T) {
 		t.Error("default field name should be used if JSON tag is not set")
 	}
 
-	// testing with non-default params: skip ignored tags & skip missing tags
-	params = StructKeysJsonParams{false, false}
+	// testing with non-default params: skip ignored fields & skip fields with missing tags
+	params = StructKeysJsonParams{true, true}
 	fields, fieldsError = ObjectKeysJson(testStructFieldsJson{}, params)
 	basicFunctionalityTests(fields, fieldsError)
 	if len(fields) != 4 {
@@ -305,10 +305,10 @@ func TestObjectKeysJson(t *testing.T) {
 		t.Error("resulting slice contains field name that should be skipped")
 	}
 
-	// testing with non-default params: do not skip ignored tags & skip missing tags
+	// testing with non-default params: do not skip ignored fields & skip fields with missing tags
 	params = StructKeysJsonParams{
-		ReplaceIgnoredFieldsWithFieldNames: true,
-		ReplaceMissingTagsWithFieldNames:   false,
+		SkipIgnoredFields: false,
+		SkipMissingFields: true,
 	}
 	fields, fieldsError = ObjectKeysJson(testStructFieldsJson{}, params)
 	basicFunctionalityTests(fields, fieldsError)
@@ -423,7 +423,7 @@ func TestStructFields(t *testing.T) {
 		t.Error("should not include method names")
 	}
 
-	fields, fieldsError = StructFields(testStructFieldsEmbedding{})
+	fields, fieldsError = StructFields(testStructFieldsNesting{})
 	if fieldsError != nil {
 		t.Error("invalid error when providing correct argument")
 	}
@@ -431,10 +431,10 @@ func TestStructFields(t *testing.T) {
 		t.Error("invalid resulting slice length")
 	}
 	if !IncludesString(fields, "testStructFields") {
-		t.Error("resulting slice should contain the name of the embedded struct as an entry")
+		t.Error("resulting slice should contain the name of the nested struct as an entry")
 	}
 	if IncludesString(fields, "Public") || IncludesString(fields, "private") {
-		t.Error("resulting slice should not contain any embedded struct field names")
+		t.Error("resulting slice should not contain any nested struct field names")
 	}
 }
 
@@ -451,19 +451,19 @@ func TestStructFieldsJson(t *testing.T) {
 		t.Error("invalid returned value when providing the wrong argument type")
 	}
 
-	// testing embedding
+	// testing nesting
 	fields, fieldsError = StructFieldsJson(
-		testStructFieldsJsonEmbedding{},
+		testStructFieldsJsonNesting{},
 		DefaultStructKeysJsonParams,
 	)
 	if fieldsError != nil {
 		t.Error("invalid error when providing correct arguments")
 	}
 	if len(fields) != 3 {
-		t.Error("invalid resulting slice length when using struct with embedding")
+		t.Error("invalid resulting slice length when using struct with nesting")
 	}
 	if IncludesString(fields, "normalField") {
-		t.Error("embedded fields should not be present in the resulting slice")
+		t.Error("nested fields should not be present in the resulting slice")
 	}
 
 	// testing basic functionality regardless of the used params
@@ -515,8 +515,8 @@ func TestStructFieldsJson(t *testing.T) {
 		}
 	}
 
-	// testing with default params: do not skip ignored tags & replace missing tags with field names
-	params := StructKeysJsonParams{true, true}
+	// testing with default params: do not skip ignored fields & replace missing tags with field names
+	params := StructKeysJsonParams{false, false}
 	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
 	basicFunctionalityTests(fields, fieldsError)
 	if len(fields) != 10 {
@@ -541,10 +541,10 @@ func TestStructFieldsJson(t *testing.T) {
 		t.Error("default field name should be used if JSON tag is not set")
 	}
 
-	// testing with non-default params: skip ignored tags & replace missing tags with field names
+	// testing with non-default params: skip ignored fields & replace missing tags with field names
 	params = StructKeysJsonParams{
-		ReplaceIgnoredFieldsWithFieldNames: false,
-		ReplaceMissingTagsWithFieldNames:   true,
+		SkipIgnoredFields: true,
+		SkipMissingFields: false,
 	}
 	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
 	basicFunctionalityTests(fields, fieldsError)
@@ -570,8 +570,8 @@ func TestStructFieldsJson(t *testing.T) {
 		t.Error("default field name should be used if JSON tag is not set")
 	}
 
-	// testing with non-default params: skip ignored tags & skip missing tags
-	params = StructKeysJsonParams{false, false}
+	// testing with non-default params: skip ignored fields & skip fields with missing tags
+	params = StructKeysJsonParams{true, true}
 	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
 	basicFunctionalityTests(fields, fieldsError)
 	if len(fields) != 4 {
@@ -596,10 +596,10 @@ func TestStructFieldsJson(t *testing.T) {
 		t.Error("resulting slice contains field name that should be skipped")
 	}
 
-	// testing with non-default params: do not skip ignored tags & skip missing tags
+	// testing with non-default params: do not skip ignored fields & skip fields with missing tags
 	params = StructKeysJsonParams{
-		ReplaceIgnoredFieldsWithFieldNames: true,
-		ReplaceMissingTagsWithFieldNames:   false,
+		SkipIgnoredFields: false,
+		SkipMissingFields: true,
 	}
 	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
 	basicFunctionalityTests(fields, fieldsError)

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -6,6 +6,49 @@ import (
 	"time"
 )
 
+type animalsStruct struct {
+	Elephant string
+	Hippo    string
+	Lion     string
+}
+
+type testStructFields struct {
+	Public  string
+	private string
+}
+
+func (obj testStructFields) testMethod() string {
+	return obj.Public + obj.private
+}
+
+type testStructFieldsEmbedding struct {
+	testStructFields
+	A int
+	B string
+}
+
+type testStructFieldsJson struct {
+	Comma                int `json:","`
+	Empty                int `json:""`
+	Ignored              int `json:"-"`
+	Missing              int
+	EmptyWithOmitempty   int `json:",omitempty"`
+	IgonredWithOmitempty int `json:"-,omitempty"`
+	NormalField          int `json:"normalField"`
+	private              int `json:"private"`
+	privateWithOmitempty int `json:"privateWithOmitempty,omitempty"`
+}
+
+func (obj testStructFieldsJson) testMethod() int {
+	return obj.NormalField + obj.private
+}
+
+type testStructFieldsJsonEmbedding struct {
+	testStructFields
+	A int
+	B string
+}
+
 func TestIncludesInt(t *testing.T) {
 	arrayOfInts := []int{1, 2, 3, 4, 9}
 
@@ -64,46 +107,59 @@ func TestObjectKeys(t *testing.T) {
 	if keysError == nil {
 		t.Error("invalid handling of the wrong argument type")
 	}
-	if keysError.Error() != objectKeysTypeError {
+	if keysError.Error() != structFieldsTypeError {
 		t.Error("invalid error message when providing the wrong argument type")
 	}
 	if keys != nil {
 		t.Error("invalid returned value when providing the wrong argument type")
 	}
 
-	var testStruct objectKeysTestStruct
-
-	keys, keysError = ObjectKeys(testStruct)
+	keys, keysError = ObjectKeys(testStructFields{})
 	if keysError != nil {
 		t.Error("invalid error when providing correct argument")
 	}
 	if len(keys) != 2 {
 		t.Error("invalid resulting slice length")
 	}
-	if IncludesString(keys, "method") {
+	if IncludesString(keys, "testMethod") {
 		t.Error("should not include method names")
+	}
+
+	keys, keysError = ObjectKeys(testStructFieldsEmbedding{})
+	if keysError != nil {
+		t.Error("invalid error when providing correct argument")
+	}
+	if len(keys) != 3 {
+		t.Error("invalid resulting slice length")
+	}
+	if !IncludesString(keys, "testStructFields") {
+		t.Error("resulting slice should contain the name of the embedded struct as an entry")
+	}
+	if IncludesString(keys, "Public") || IncludesString(keys, "private") {
+		t.Error("resulting slice should not contain any embedded struct field names")
 	}
 }
 
+// TODO: finish this after completing TestStructFieldsJson
 func TestObjectKeysJson(t *testing.T) {
 	keys, keysError := ObjectKeysJson("invalid argument", DefaultStructKeysJsonParams)
 	if keysError == nil {
 		t.Error("invalid handling of the wrong argument type")
 	}
-	if keysError.Error() != objectKeysTypeError {
+	if keysError.Error() != structFieldsTypeError {
 		t.Error("invalid error message when providing the wrong argument type")
 	}
 	if keys != nil {
 		t.Error("invalid returned value when providing the wrong argument type")
 	}
 
-	var testStruct objectKeysJsonTestStruct
+	var testStruct testStructFieldsJson
 
 	keys, keysError = ObjectKeysJson(testStruct, DefaultStructKeysJsonParams)
 }
 
 func TestObjectValues(t *testing.T) {
-	animals := animals{
+	animals := animalsStruct{
 		Elephant: "elephant",
 		Hippo:    "hippo",
 		Lion:     "lion",
@@ -141,42 +197,55 @@ func TestStructFields(t *testing.T) {
 	if fieldsError == nil {
 		t.Error("invalid handling of the wrong argument type")
 	}
-	if fieldsError.Error() != objectKeysTypeError {
+	if fieldsError.Error() != structFieldsTypeError {
 		t.Error("invalid error message when providing the wrong argument type")
 	}
 	if fields != nil {
 		t.Error("invalid returned value when providing the wrong argument type")
 	}
 
-	var testStruct objectKeysTestStruct
-
-	fields, fieldsError = StructFields(testStruct)
+	fields, fieldsError = StructFields(testStructFields{})
 	if fieldsError != nil {
 		t.Error("invalid error when providing correct argument")
 	}
 	if len(fields) != 2 {
 		t.Error("invalid resulting slice length")
 	}
-	if IncludesString(fields, "method") {
+	if IncludesString(fields, "testMethod") {
 		t.Error("should not include method names")
+	}
+
+	fields, fieldsError = StructFields(testStructFieldsEmbedding{})
+	if fieldsError != nil {
+		t.Error("invalid error when providing correct argument")
+	}
+	if len(fields) != 3 {
+		t.Error("invalid resulting slice length")
+	}
+	if !IncludesString(fields, "testStructFields") {
+		t.Error("resulting slice should contain the name of the embedded struct as an entry")
+	}
+	if IncludesString(fields, "Public") || IncludesString(fields, "private") {
+		t.Error("resulting slice should not contain any embedded struct field names")
 	}
 }
 
 func TestStructFieldsJson(t *testing.T) {
+	// testing with invalid argument type
 	fields, fieldsError := StructFieldsJson("invalid argument", DefaultStructKeysJsonParams)
 	if fieldsError == nil {
 		t.Error("invalid handling of the wrong argument type")
 	}
-	if fieldsError.Error() != objectKeysTypeError {
+	if fieldsError.Error() != structFieldsTypeError {
 		t.Error("invalid error message when providing the wrong argument type")
 	}
 	if fields != nil {
 		t.Error("invalid returned value when providing the wrong argument type")
 	}
 
-	var testStruct objectKeysJsonTestStruct
-
-	fields, fieldsError = StructFieldsJson(testStruct, DefaultStructKeysJsonParams)
+	// testing with default params: do not skip ignored tags & replace missing tags with field names
+	params := StructKeysJsonParams{true, true}
+	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
 	if fieldsError != nil {
 		t.Error("invalid error when providing correct arguments")
 	}
@@ -184,16 +253,17 @@ func TestStructFieldsJson(t *testing.T) {
 		t.Error("resulting slice should not be empty when using default params")
 	}
 
-	params := StructKeysJsonParams{
+	// testing with non-default params: skip ignored tags & replace missing tags with field names
+	params = StructKeysJsonParams{
 		ReplaceIgnoredFieldsWithFieldNames: false,
 		ReplaceMissingTagsWithFieldNames:   true,
 	}
-	fields, fieldsError = StructFieldsJson(testStruct, params)
+	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
 	if fieldsError != nil {
 		t.Error("invalid error when providing correct arguments")
 	}
 	if IncludesString(fields, "Ignored") {
-		t.Error("resulting slice contains field name that should be ignored according to params")
+		t.Error("resulting slice contains field name that should be skipped according to params")
 	}
 	if IncludesString(fields, "IgnoredWithOmitempty") {
 		t.Error("resulting slice contains field name that should be ignored according to params")
@@ -203,7 +273,7 @@ func TestStructFieldsJson(t *testing.T) {
 	}
 
 	params = StructKeysJsonParams{false, false}
-	fields, fieldsError = StructFieldsJson(testStruct, params)
+	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
 	if fieldsError != nil {
 		t.Error("invalid error when providing correct argument type")
 	}
@@ -217,7 +287,7 @@ func TestStructFieldsJson(t *testing.T) {
 }
 
 func TestStructValues(t *testing.T) {
-	animals := animals{
+	animals := animalsStruct{
 		Elephant: "elephant",
 		Hippo:    "hippo",
 		Lion:     "lion",

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -28,15 +28,16 @@ type testStructFieldsEmbedding struct {
 }
 
 type testStructFieldsJson struct {
-	Comma                int `json:","`
-	Empty                int `json:""`
-	Ignored              int `json:"-"`
-	Missing              int
-	EmptyWithOmitempty   int `json:",omitempty"`
-	IgonredWithOmitempty int `json:"-,omitempty"`
-	NormalField          int `json:"normalField"`
-	private              int `json:"private"`
-	privateWithOmitempty int `json:"privateWithOmitempty,omitempty"`
+	Comma                    int `json:","`
+	Empty                    int `json:""`
+	Ignored                  int `json:"-"`
+	Missing                  int
+	EmptyWithOmitempty       int `json:",omitempty"`
+	IgonredWithOmitempty     int `json:"-,omitempty"`
+	NormalField              int `json:"normalField"`
+	NormalFieldWithOmitempty int `json:"normalFieldWithOmitempty,omitempty"`
+	private                  int `json:"private"`
+	privateWithOmitempty     int `json:"privateWithOmitempty,omitempty"`
 }
 
 func (obj testStructFieldsJson) testMethod() int {
@@ -45,8 +46,8 @@ func (obj testStructFieldsJson) testMethod() int {
 
 type testStructFieldsJsonEmbedding struct {
 	testStructFields
-	A int
-	B string
+	A int    `json:"a"`
+	B string `json:"b"`
 }
 
 func TestIncludesInt(t *testing.T) {
@@ -140,22 +141,192 @@ func TestObjectKeys(t *testing.T) {
 	}
 }
 
-// TODO: finish this after completing TestStructFieldsJson
 func TestObjectKeysJson(t *testing.T) {
-	keys, keysError := ObjectKeysJson("invalid argument", DefaultStructKeysJsonParams)
-	if keysError == nil {
+	// testing with invalid argument type
+	fields, fieldsError := ObjectKeysJson("invalid argument", DefaultStructKeysJsonParams)
+	if fieldsError == nil {
 		t.Error("invalid handling of the wrong argument type")
 	}
-	if keysError.Error() != structFieldsTypeError {
+	if fieldsError.Error() != structFieldsTypeError {
 		t.Error("invalid error message when providing the wrong argument type")
 	}
-	if keys != nil {
+	if fields != nil {
 		t.Error("invalid returned value when providing the wrong argument type")
 	}
 
-	var testStruct testStructFieldsJson
+	// testing embedding
+	fields, fieldsError = ObjectKeysJson(
+		testStructFieldsJsonEmbedding{},
+		DefaultStructKeysJsonParams,
+	)
+	if fieldsError != nil {
+		t.Error("invalid error when providing correct arguments")
+	}
+	if len(fields) != 3 {
+		t.Error("invalid resulting slice length when using struct with embedding")
+	}
+	if IncludesString(fields, "normalField") {
+		t.Error("embedded fields should not be present in the resulting slice")
+	}
 
-	keys, keysError = ObjectKeysJson(testStruct, DefaultStructKeysJsonParams)
+	// testing basic functionality regardless of the used params
+	basicFunctionalityTests := func(fields []string, fieldsError error) {
+		if fieldsError != nil {
+			t.Error("invalid error when providing correct arguments")
+		}
+		if len(fields) == 0 {
+			t.Error("resulting slice should not be empty")
+		}
+		if IncludesString(fields, "testMethod") {
+			t.Error("resulting slice should not include method names")
+		}
+		if !IncludesString(fields, "normalField") {
+			t.Error("resulting slice should contain non-private field tags without any modifiers")
+		}
+		if !IncludesString(fields, "normalFieldWithOmitempty") {
+			t.Error(
+				"resulting slice should contain non-private field tags with 'omitempty' modifier",
+			)
+		}
+		if IncludesString(fields, "normalFieldWithOmitempty,omitempty") {
+			t.Error(
+				"the 'omitempty' substring should be removed from the tag string for non-private fields",
+			)
+		}
+		if !IncludesString(fields, "private") {
+			t.Error("resulting slice should contain private field tags or field names")
+		}
+		if !IncludesString(fields, "privateWithOmitempty") {
+			t.Error("resulting slice should contain private field tags with 'omitempty' modifier")
+		}
+		if IncludesString(fields, "privateWithOmitempty,omitempty") {
+			t.Error(
+				"the 'omitempty' substring should be removed from the tag string for private fields",
+			)
+		}
+		if IncludesString(fields, "-") {
+			t.Error("resulting slice should not contain '-' symbol")
+		}
+		if IncludesString(fields, "-,omitempty") {
+			t.Error("resulting slice should not contain '-,omitempty'")
+		}
+		if IncludesString(fields, ",") {
+			t.Error("resulting slice should not contain ',' symbol")
+		}
+		if IncludesString(fields, ",omitempty") {
+			t.Error("resulting slice should not contain ',omitempty'")
+		}
+	}
+
+	// testing with default params: do not skip ignored tags & replace missing tags with field names
+	params := StructKeysJsonParams{true, true}
+	fields, fieldsError = ObjectKeysJson(testStructFieldsJson{}, params)
+	basicFunctionalityTests(fields, fieldsError)
+	if len(fields) != 10 {
+		t.Error("invalid resulting slice length")
+	}
+	if !IncludesString(fields, "Ignored") {
+		t.Error("resulting slice should contain ignored field name")
+	}
+	if !IncludesString(fields, "IgonredWithOmitempty") {
+		t.Error("resulting slice should contain ignored field name even if it has 'omitempty'")
+	}
+	if !IncludesString(fields, "Comma") {
+		t.Error("default field name should be used if JSON tag string is ','")
+	}
+	if !IncludesString(fields, "Empty") {
+		t.Error("default field name should be used if JSON tag is an empty string")
+	}
+	if !IncludesString(fields, "EmptyWithOmitempty") {
+		t.Error("default field name should be used if JSON tag string is ',omitempty'")
+	}
+	if !IncludesString(fields, "Missing") {
+		t.Error("default field name should be used if JSON tag is not set")
+	}
+
+	// testing with non-default params: skip ignored tags & replace missing tags with field names
+	params = StructKeysJsonParams{
+		ReplaceIgnoredFieldsWithFieldNames: false,
+		ReplaceMissingTagsWithFieldNames:   true,
+	}
+	fields, fieldsError = ObjectKeysJson(testStructFieldsJson{}, params)
+	basicFunctionalityTests(fields, fieldsError)
+	if len(fields) != 8 {
+		t.Error("resulting slice has invalid length")
+	}
+	if IncludesString(fields, "Ignored") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "IgnoredWithOmitempty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if !IncludesString(fields, "Comma") {
+		t.Error("default field name should be used if JSON tag string is ','")
+	}
+	if !IncludesString(fields, "Empty") {
+		t.Error("default field name should be used if JSON tag is an empty string")
+	}
+	if !IncludesString(fields, "EmptyWithOmitempty") {
+		t.Error("default field name should be used if JSON tag string is ',omitempty'")
+	}
+	if !IncludesString(fields, "Missing") {
+		t.Error("default field name should be used if JSON tag is not set")
+	}
+
+	// testing with non-default params: skip ignored tags & skip missing tags
+	params = StructKeysJsonParams{false, false}
+	fields, fieldsError = ObjectKeysJson(testStructFieldsJson{}, params)
+	basicFunctionalityTests(fields, fieldsError)
+	if len(fields) != 4 {
+		t.Error("resulting slice has invalid length")
+	}
+	if IncludesString(fields, "Ignored") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "IgnoredWithOmitempty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "Comma") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "Empty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "EmptyWithOmitempty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "Missing") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+
+	// testing with non-default params: do not skip ignored tags & skip missing tags
+	params = StructKeysJsonParams{
+		ReplaceIgnoredFieldsWithFieldNames: true,
+		ReplaceMissingTagsWithFieldNames:   false,
+	}
+	fields, fieldsError = ObjectKeysJson(testStructFieldsJson{}, params)
+	basicFunctionalityTests(fields, fieldsError)
+	if len(fields) != 6 {
+		t.Error("invalid resulting slice length")
+	}
+	if !IncludesString(fields, "Ignored") {
+		t.Error("resulting slice should contain ignored field name")
+	}
+	if !IncludesString(fields, "IgonredWithOmitempty") {
+		t.Error("resulting slice should contain ignored field name even if it has 'omitempty'")
+	}
+	if IncludesString(fields, "Comma") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "Empty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "EmptyWithOmitempty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "Missing") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
 }
 
 func TestObjectValues(t *testing.T) {
@@ -243,14 +414,94 @@ func TestStructFieldsJson(t *testing.T) {
 		t.Error("invalid returned value when providing the wrong argument type")
 	}
 
-	// testing with default params: do not skip ignored tags & replace missing tags with field names
-	params := StructKeysJsonParams{true, true}
-	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
+	// testing embedding
+	fields, fieldsError = StructFieldsJson(
+		testStructFieldsJsonEmbedding{},
+		DefaultStructKeysJsonParams,
+	)
 	if fieldsError != nil {
 		t.Error("invalid error when providing correct arguments")
 	}
-	if len(fields) == 0 {
-		t.Error("resulting slice should not be empty when using default params")
+	if len(fields) != 3 {
+		t.Error("invalid resulting slice length when using struct with embedding")
+	}
+	if IncludesString(fields, "normalField") {
+		t.Error("embedded fields should not be present in the resulting slice")
+	}
+
+	// testing basic functionality regardless of the used params
+	basicFunctionalityTests := func(fields []string, fieldsError error) {
+		if fieldsError != nil {
+			t.Error("invalid error when providing correct arguments")
+		}
+		if len(fields) == 0 {
+			t.Error("resulting slice should not be empty")
+		}
+		if IncludesString(fields, "testMethod") {
+			t.Error("resulting slice should not include method names")
+		}
+		if !IncludesString(fields, "normalField") {
+			t.Error("resulting slice should contain non-private field tags without any modifiers")
+		}
+		if !IncludesString(fields, "normalFieldWithOmitempty") {
+			t.Error(
+				"resulting slice should contain non-private field tags with 'omitempty' modifier",
+			)
+		}
+		if IncludesString(fields, "normalFieldWithOmitempty,omitempty") {
+			t.Error(
+				"the 'omitempty' substring should be removed from the tag string for non-private fields",
+			)
+		}
+		if !IncludesString(fields, "private") {
+			t.Error("resulting slice should contain private field tags or field names")
+		}
+		if !IncludesString(fields, "privateWithOmitempty") {
+			t.Error("resulting slice should contain private field tags with 'omitempty' modifier")
+		}
+		if IncludesString(fields, "privateWithOmitempty,omitempty") {
+			t.Error(
+				"the 'omitempty' substring should be removed from the tag string for private fields",
+			)
+		}
+		if IncludesString(fields, "-") {
+			t.Error("resulting slice should not contain '-' symbol")
+		}
+		if IncludesString(fields, "-,omitempty") {
+			t.Error("resulting slice should not contain '-,omitempty'")
+		}
+		if IncludesString(fields, ",") {
+			t.Error("resulting slice should not contain ',' symbol")
+		}
+		if IncludesString(fields, ",omitempty") {
+			t.Error("resulting slice should not contain ',omitempty'")
+		}
+	}
+
+	// testing with default params: do not skip ignored tags & replace missing tags with field names
+	params := StructKeysJsonParams{true, true}
+	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
+	basicFunctionalityTests(fields, fieldsError)
+	if len(fields) != 10 {
+		t.Error("invalid resulting slice length")
+	}
+	if !IncludesString(fields, "Ignored") {
+		t.Error("resulting slice should contain ignored field name")
+	}
+	if !IncludesString(fields, "IgonredWithOmitempty") {
+		t.Error("resulting slice should contain ignored field name even if it has 'omitempty'")
+	}
+	if !IncludesString(fields, "Comma") {
+		t.Error("default field name should be used if JSON tag string is ','")
+	}
+	if !IncludesString(fields, "Empty") {
+		t.Error("default field name should be used if JSON tag is an empty string")
+	}
+	if !IncludesString(fields, "EmptyWithOmitempty") {
+		t.Error("default field name should be used if JSON tag string is ',omitempty'")
+	}
+	if !IncludesString(fields, "Missing") {
+		t.Error("default field name should be used if JSON tag is not set")
 	}
 
 	// testing with non-default params: skip ignored tags & replace missing tags with field names
@@ -259,31 +510,83 @@ func TestStructFieldsJson(t *testing.T) {
 		ReplaceMissingTagsWithFieldNames:   true,
 	}
 	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
-	if fieldsError != nil {
-		t.Error("invalid error when providing correct arguments")
-	}
-	if IncludesString(fields, "Ignored") {
-		t.Error("resulting slice contains field name that should be skipped according to params")
-	}
-	if IncludesString(fields, "IgnoredWithOmitempty") {
-		t.Error("resulting slice contains field name that should be ignored according to params")
-	}
-	if len(fields) != 7 {
+	basicFunctionalityTests(fields, fieldsError)
+	if len(fields) != 8 {
 		t.Error("resulting slice has invalid length")
 	}
-
-	params = StructKeysJsonParams{false, false}
-	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
-	if fieldsError != nil {
-		t.Error("invalid error when providing correct argument type")
-	}
 	if IncludesString(fields, "Ignored") {
-		t.Error("resulting slice contains field name that should be ignored according to params")
+		t.Error("resulting slice contains field name that should be skipped")
 	}
 	if IncludesString(fields, "IgnoredWithOmitempty") {
-		t.Error("resulting slice contains field name that should be ignored according to params")
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if !IncludesString(fields, "Comma") {
+		t.Error("default field name should be used if JSON tag string is ','")
+	}
+	if !IncludesString(fields, "Empty") {
+		t.Error("default field name should be used if JSON tag is an empty string")
+	}
+	if !IncludesString(fields, "EmptyWithOmitempty") {
+		t.Error("default field name should be used if JSON tag string is ',omitempty'")
+	}
+	if !IncludesString(fields, "Missing") {
+		t.Error("default field name should be used if JSON tag is not set")
 	}
 
+	// testing with non-default params: skip ignored tags & skip missing tags
+	params = StructKeysJsonParams{false, false}
+	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
+	basicFunctionalityTests(fields, fieldsError)
+	if len(fields) != 4 {
+		t.Error("resulting slice has invalid length")
+	}
+	if IncludesString(fields, "Ignored") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "IgnoredWithOmitempty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "Comma") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "Empty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "EmptyWithOmitempty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "Missing") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+
+	// testing with non-default params: do not skip ignored tags & skip missing tags
+	params = StructKeysJsonParams{
+		ReplaceIgnoredFieldsWithFieldNames: true,
+		ReplaceMissingTagsWithFieldNames:   false,
+	}
+	fields, fieldsError = StructFieldsJson(testStructFieldsJson{}, params)
+	basicFunctionalityTests(fields, fieldsError)
+	if len(fields) != 6 {
+		t.Error("invalid resulting slice length")
+	}
+	if !IncludesString(fields, "Ignored") {
+		t.Error("resulting slice should contain ignored field name")
+	}
+	if !IncludesString(fields, "IgonredWithOmitempty") {
+		t.Error("resulting slice should contain ignored field name even if it has 'omitempty'")
+	}
+	if IncludesString(fields, "Comma") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "Empty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "EmptyWithOmitempty") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
+	if IncludesString(fields, "Missing") {
+		t.Error("resulting slice contains field name that should be skipped")
+	}
 }
 
 func TestStructValues(t *testing.T) {

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -60,18 +60,18 @@ func TestMakeTimestampSeconds(t *testing.T) {
 }
 
 func TestObjectKeys(t *testing.T) {
-	var testStruct objectKeysTestStruct
-
 	keys, keysError := ObjectKeys("invalid argument")
 	if keysError == nil {
 		t.Error("invalid handling of the wrong argument type")
 	}
-	if keysError.Error() != OBJECT_KEYS_TYPE_ERROR {
+	if keysError.Error() != objectKeysTypeError {
 		t.Error("invalid error message when providing the wrong argument type")
 	}
 	if keys != nil {
 		t.Error("invalid returned value when providing the wrong argument type")
 	}
+
+	var testStruct objectKeysTestStruct
 
 	keys, keysError = ObjectKeys(testStruct)
 	if keysError != nil {
@@ -85,14 +85,25 @@ func TestObjectKeys(t *testing.T) {
 	}
 }
 
-func TestObjectValues(t *testing.T) {
-	type Animals struct {
-		Elephant string
-		Hippo    string
-		Lion     string
+func TestObjectKeysJson(t *testing.T) {
+	keys, keysError := ObjectKeysJson("invalid argument", DefaultStructKeysJsonParams)
+	if keysError == nil {
+		t.Error("invalid handling of the wrong argument type")
+	}
+	if keysError.Error() != objectKeysTypeError {
+		t.Error("invalid error message when providing the wrong argument type")
+	}
+	if keys != nil {
+		t.Error("invalid returned value when providing the wrong argument type")
 	}
 
-	animals := Animals{
+	var testStruct objectKeysJsonTestStruct
+
+	keys, keysError = ObjectKeysJson(testStruct, DefaultStructKeysJsonParams)
+}
+
+func TestObjectValues(t *testing.T) {
+	animals := animals{
 		Elephant: "elephant",
 		Hippo:    "hippo",
 		Lion:     "lion",
@@ -122,5 +133,102 @@ func TestRandomString(t *testing.T) {
 	randomString := RandomString(32)
 	if len(randomString) != 32 {
 		t.Error("invalid string length")
+	}
+}
+
+func TestStructFields(t *testing.T) {
+	fields, fieldsError := StructFields("invalid argument")
+	if fieldsError == nil {
+		t.Error("invalid handling of the wrong argument type")
+	}
+	if fieldsError.Error() != objectKeysTypeError {
+		t.Error("invalid error message when providing the wrong argument type")
+	}
+	if fields != nil {
+		t.Error("invalid returned value when providing the wrong argument type")
+	}
+
+	var testStruct objectKeysTestStruct
+
+	fields, fieldsError = StructFields(testStruct)
+	if fieldsError != nil {
+		t.Error("invalid error when providing correct argument")
+	}
+	if len(fields) != 2 {
+		t.Error("invalid resulting slice length")
+	}
+	if IncludesString(fields, "method") {
+		t.Error("should not include method names")
+	}
+}
+
+func TestStructFieldsJson(t *testing.T) {
+	fields, fieldsError := StructFieldsJson("invalid argument", DefaultStructKeysJsonParams)
+	if fieldsError == nil {
+		t.Error("invalid handling of the wrong argument type")
+	}
+	if fieldsError.Error() != objectKeysTypeError {
+		t.Error("invalid error message when providing the wrong argument type")
+	}
+	if fields != nil {
+		t.Error("invalid returned value when providing the wrong argument type")
+	}
+
+	var testStruct objectKeysJsonTestStruct
+
+	fields, fieldsError = StructFieldsJson(testStruct, DefaultStructKeysJsonParams)
+	if fieldsError != nil {
+		t.Error("invalid error when providing correct arguments")
+	}
+	if len(fields) == 0 {
+		t.Error("resulting slice should not be empty when using default params")
+	}
+
+	params := StructKeysJsonParams{
+		ReplaceIgnoredFieldsWithFieldNames: false,
+		ReplaceMissingTagsWithFieldNames:   true,
+	}
+	fields, fieldsError = StructFieldsJson(testStruct, params)
+	if fieldsError != nil {
+		t.Error("invalid error when providing correct arguments")
+	}
+	if IncludesString(fields, "Ignored") {
+		t.Error("resulting slice contains field name that should be ignored according to params")
+	}
+	if IncludesString(fields, "IgnoredWithOmitempty") {
+		t.Error("resulting slice contains field name that should be ignored according to params")
+	}
+	if len(fields) != 7 {
+		t.Error("resulting slice has invalid length")
+	}
+
+	params = StructKeysJsonParams{false, false}
+	fields, fieldsError = StructFieldsJson(testStruct, params)
+	if fieldsError != nil {
+		t.Error("invalid error when providing correct argument type")
+	}
+	if IncludesString(fields, "Ignored") {
+		t.Error("resulting slice contains field name that should be ignored according to params")
+	}
+	if IncludesString(fields, "IgnoredWithOmitempty") {
+		t.Error("resulting slice contains field name that should be ignored according to params")
+	}
+
+}
+
+func TestStructValues(t *testing.T) {
+	animals := animals{
+		Elephant: "elephant",
+		Hippo:    "hippo",
+		Lion:     "lion",
+	}
+
+	values := StructValues(animals)
+	if len(values) != 3 {
+		t.Error("invalid resulting slice length")
+	}
+
+	if !IncludesString(values, "lion") {
+		t.Error("invalid values are included in resulting slice")
 	}
 }


### PR DESCRIPTION
v1.0.4:
- Renamed `ObjectValues` function to `StructValues`, added an alias for compatibility
- Updated tests for `StructValues` function, now it have full coverage
- Added `StructFields` function with an alias `ObjectKeys`, added tests for it
- Added `StructFieldsJson` function with an alias `ObjectKeysJson`, added tests for it
- Updated README